### PR TITLE
Use config file for C++ Instrumentation API 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,9 @@
 # Generic CMake settings for SALT
 #--------------------------------
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.23.0)
 # Ensure policies are set as they have been tested
-cmake_policy(VERSION 3.13.1...3.31.2)
+cmake_policy(VERSION 3.23.0...3.31.2)
 if(POLICY CMP0144)
   cmake_policy(SET CMP0144 NEW)
 endif()

--- a/config_files/tau_config.yaml
+++ b/config_files/tau_config.yaml
@@ -15,9 +15,21 @@ main_insert:
   - "#endif /* TAU_MPI */"
   - "    TAU_PROFILE_START(tautimer);"
 
+main_insert_scope:
+  - "    TAU_INIT(&argc, &argv);"
+  - "#ifndef TAU_MPI"
+  - "#ifndef TAU_SHMEM"
+  - "    TAU_PROFILE_SET_NODE(0);"
+  - "#endif /* TAU_SHMEM */"
+  - "#endif /* TAU_MPI */"
+  - "    TAU_PROFILE(\"${full_timer_name}\", \" \", TAU_DEFAULT);"
+
 function_begin_insert:
   - "    TAU_PROFILE_TIMER(tautimer, \"${full_timer_name}\", \" \", TAU_USER);"
   - "    TAU_PROFILE_START(tautimer);"
+
+function_begin_insert_scope:
+  - "    TAU_PROFILE(\"${full_timer_name}\", \" \", TAU_USER);"
 
 function_end_insert:
   - "TAU_PROFILE_STOP(tautimer);"


### PR DESCRIPTION
When using the C++ Instrumentation API, hard-coded text was used for insertion instead of reading from the config file. With this pull request, config file text is used for both C and C++ Instrumentation APIs. Adds new config file entries `main_insert_scope` and `function_begin_insert_scope` to support the C++ Instrumentation API which uses timer objects to automatically stop the timer when it leaves scope. 

Additionally, updates minimum CMake to 3.23.0. An earlier change introduced the use of a feature (`FILE_SET`) which requires at least this version.

Fixes #41 and #42.