### PR TITLE
docs(changelog): promote Unreleased to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-08
+
 - macOS build support and LLVM 22 added to the CI test matrix; bumps
   `.VERSION` to 0.4.0 and makes `cparse-llvm --version` report the SALT
   version (previously only the LLVM banner)
@@ -159,6 +161,7 @@ tag, ending with the v0.2.0 SALT-FM milestone.
 - Build fixed under Clang 15 with stricter pedantic diagnostics
   ([#13](https://github.com/ParaToolsInc/salt/pull/13) by @khuck).
 
-[Unreleased]: https://github.com/ParaToolsInc/salt/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/ParaToolsInc/salt/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/ParaToolsInc/salt/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/ParaToolsInc/salt/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/ParaToolsInc/salt/releases/tag/v0.2.0


### PR DESCRIPTION
Stamp release date 2026-05-08 ahead of v0.4.0 tag; add new empty [Unreleased] heading and update compare links.