### PR TITLE
fix unquoted leading-# wildcards in select files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Selective instrumentation files now accept unquoted patterns starting
+  with the `#` wildcard inside `BEGIN_`/`END_` list blocks; `#` starts a
+  comment only outside list blocks, matching TAU's LLVM plugin. Quoted
+  patterns keep working. Suspicious quoting (missing closing quote, text
+  after the closing quote, empty quoted pattern) now emits a warning
+  instead of silently altering the entry
+  ([#65](https://github.com/ParaToolsInc/SALT-FM/pull/65) by @zbeekman):
+  - [#64](https://github.com/ParaToolsInc/SALT-FM/issues/64) - exclude
+    list entries starting with a wildcard were dropped as comments unless
+    quoted (reported by @giltirn).
+
 ## [0.4.1] - 2026-05-12
 
 - macOS build robustness: configure-time auto-detection of

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1134,9 +1134,11 @@ set_tests_properties(instrument_sif_exclusion_empty_quote_cpp
   PROPERTIES
   PASS_REGULAR_EXPRESSION "WARNING: empty quoted exclude list entry"
 )
+# Single regex spanning both timers (source order): a list here would be
+# OR'd, not AND'd. CMake's '.' matches newlines.
 set_tests_properties(check_sif_exclusion_empty_quote_cpp
   PROPERTIES
-  PASS_REGULAR_EXPRESSION "dosomething_noinst[(]void[)] +\\[\\{"
+  PASS_REGULAR_EXPRESSION "dosomething_inst[(]void[)] +\\[\\{.*dosomething_noinst[(]void[)] +\\[\\{"
 )
 
 # File-level EXCLUDE_LIST: the C/C++ frontend short-circuits and emits no

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1284,6 +1284,15 @@ if(TEST_FORTRAN)
     FAIL_REGULAR_EXPRESSION "${_sif_keep_pattern_fortran};${_sif_excluded_pattern_fortran}"
   )
 
+  # Unquoted twin of the wildcard sanity check above (issue #64): same
+  # pattern without quotes must behave identically.
+  add_sif_test(routine_unquoted_wildcard_excludes_both_fortran
+    fortran tests/fortran/sif_excl.f90 tests/sif/exclude_unquoted_wildcard_routine_f90.tau)
+  set_tests_properties(check_sif_routine_unquoted_wildcard_excludes_both_fortran
+    PROPERTIES
+    FAIL_REGULAR_EXPRESSION "${_sif_keep_pattern_fortran};${_sif_excluded_pattern_fortran}"
+  )
+
   # Combined INCLUDE + EXCLUDE: per the TAU SIF spec the exclude list
   # operates on whatever survives the include filter. The SIF below
   # whitelists "#routine" (matches both subprograms) and then explicitly
@@ -1291,6 +1300,15 @@ if(TEST_FORTRAN)
   add_sif_test(include_wildcard_exclude_specific_fortran
     fortran tests/fortran/sif_excl.f90 tests/sif/include_wildcard_exclude_specific_f90.tau)
   set_tests_properties(check_sif_include_wildcard_exclude_specific_fortran
+    PROPERTIES
+    PASS_REGULAR_EXPRESSION "${_sif_keep_pattern_fortran}"
+    FAIL_REGULAR_EXPRESSION "${_sif_excluded_pattern_fortran}"
+  )
+  # Unquoted twin of the combined INCLUDE + EXCLUDE test (issue #64 applies
+  # to every list kind). Same expectations as the quoted version.
+  add_sif_test(include_unquoted_wildcard_exclude_specific_fortran
+    fortran tests/fortran/sif_excl.f90 tests/sif/include_unquoted_wildcard_f90.tau)
+  set_tests_properties(check_sif_include_unquoted_wildcard_exclude_specific_fortran
     PROPERTIES
     PASS_REGULAR_EXPRESSION "${_sif_keep_pattern_fortran}"
     FAIL_REGULAR_EXPRESSION "${_sif_excluded_pattern_fortran}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1098,6 +1098,47 @@ set_tests_properties(check_sif_exclusion_unquoted_wildcard_prefix_cpp
   FAIL_REGULAR_EXPRESSION "dosomething_noinst[(]void[)] +\\[\\{"
 )
 
+# Suspicious quoting in list entries must produce a stderr warning while
+# parsing stays lenient (TAU-compatible). The instrument step asserts the
+# warning text; the check step asserts the lenient parse result.
+# - unclosed quote: pattern = rest of line, still excludes noinst
+# - text after closing quote: dropped, pattern still excludes noinst
+# - lone quote: empty pattern, matches nothing, both routines keep timers
+add_sif_test(exclusion_unclosed_quote_cpp
+  cpp tests/sif_excl_wildcard_prefix.cpp tests/sif/exclude_unclosed_quote_cpp.tau)
+set_tests_properties(instrument_sif_exclusion_unclosed_quote_cpp
+  PROPERTIES
+  PASS_REGULAR_EXPRESSION "WARNING: missing closing quote in exclude list entry"
+)
+set_tests_properties(check_sif_exclusion_unclosed_quote_cpp
+  PROPERTIES
+  PASS_REGULAR_EXPRESSION "dosomething_inst[(]void[)] +\\[\\{"
+  FAIL_REGULAR_EXPRESSION "dosomething_noinst[(]void[)] +\\[\\{"
+)
+
+add_sif_test(exclusion_quote_trailing_junk_cpp
+  cpp tests/sif_excl_wildcard_prefix.cpp tests/sif/exclude_quote_trailing_junk_cpp.tau)
+set_tests_properties(instrument_sif_exclusion_quote_trailing_junk_cpp
+  PROPERTIES
+  PASS_REGULAR_EXPRESSION "WARNING: ignoring text after closing quote in exclude list entry"
+)
+set_tests_properties(check_sif_exclusion_quote_trailing_junk_cpp
+  PROPERTIES
+  PASS_REGULAR_EXPRESSION "dosomething_inst[(]void[)] +\\[\\{"
+  FAIL_REGULAR_EXPRESSION "dosomething_noinst[(]void[)] +\\[\\{"
+)
+
+add_sif_test(exclusion_empty_quote_cpp
+  cpp tests/sif_excl_wildcard_prefix.cpp tests/sif/exclude_empty_quote_cpp.tau)
+set_tests_properties(instrument_sif_exclusion_empty_quote_cpp
+  PROPERTIES
+  PASS_REGULAR_EXPRESSION "WARNING: empty quoted exclude list entry"
+)
+set_tests_properties(check_sif_exclusion_empty_quote_cpp
+  PROPERTIES
+  PASS_REGULAR_EXPRESSION "dosomething_noinst[(]void[)] +\\[\\{"
+)
+
 # File-level EXCLUDE_LIST: the C/C++ frontend short-circuits and emits no
 # .inst output at all when the source file is on the file exclude list.
 # Verified via absence of the "Instrumentation:" banner from cparse-llvm.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1084,6 +1084,20 @@ foreach(lang c cpp)
   )
 endforeach()
 
+# Issue #64: an exclude pattern that starts with the '#' wildcard, written
+# WITHOUT quotes, must still be parsed as a pattern inside the
+# BEGIN_/END_EXCLUDE_LIST block (TAU's LLVM plugin accepts this form; only
+# lines outside a list block are comments). Reproducer from the issue:
+# "#noinst#" must strip dosomething_noinst's timer while dosomething_inst
+# stays instrumented.
+add_sif_test(exclusion_unquoted_wildcard_prefix_cpp
+  cpp tests/sif_excl_wildcard_prefix.cpp tests/sif/exclude_unquoted_wildcard_prefix_cpp.tau)
+set_tests_properties(check_sif_exclusion_unquoted_wildcard_prefix_cpp
+  PROPERTIES
+  PASS_REGULAR_EXPRESSION "dosomething_inst[(]void[)] +\\[\\{"
+  FAIL_REGULAR_EXPRESSION "dosomething_noinst[(]void[)] +\\[\\{"
+)
+
 # File-level EXCLUDE_LIST: the C/C++ frontend short-circuits and emits no
 # .inst output at all when the source file is on the file exclude list.
 # Verified via absence of the "Instrumentation:" banner from cparse-llvm.

--- a/src/selectfile.cpp
+++ b/src/selectfile.cpp
@@ -819,7 +819,7 @@ bool processInstrumentationRequests(const char *fname)
         else {
           fileincludelist.push_back(std::string(inbuf));
         }
-      	DPRINT("Parsing inst. file: adding %s to file include list\n", inbuf);
+	DPRINT("Parsing inst. file: adding %s to file include list\n", inbuf);
       }
     }
 

--- a/src/selectfile.cpp
+++ b/src/selectfile.cpp
@@ -3,6 +3,7 @@
 #include <fstream>
 #include <vector>
 #include <string>
+#include <cstdio>
 #include <cstring>
 #include <set>
 

--- a/src/selectfile.cpp
+++ b/src/selectfile.cpp
@@ -685,7 +685,37 @@ void parseError(const char *message, char *line, int lineno, int column)
 //
 // } // END void parseInstrumentationCommand(char *line, int lineno)
 
-#define SALT_UNUSED(expr) do { (void)(expr); } while (0)
+/* Strip optional surrounding quotes from a list-block entry. Quoting lets a
+   pattern start with '#' unambiguously in files shared with older TAU tools;
+   the closing quote is optional for TAU compatibility. Warns about quoting
+   that silently changes or ignores part of the entry. */
+static std::string parseListEntry(const char *entry, const char *listname, int lineno)
+{
+  std::string result(entry);
+  if (result[0] != '"') {
+    return result;
+  }
+  const size_t close = result.find('"', 1);
+  if (close == std::string::npos) {
+    result.erase(0, 1);
+    fprintf(stderr,
+      "WARNING: missing closing quote in %s entry at selective instrumentation file line %d; using '%s'\n",
+      listname, lineno, result.c_str());
+  } else {
+    if (close + 1 < result.size()) {
+      fprintf(stderr,
+        "WARNING: ignoring text after closing quote in %s entry at selective instrumentation file line %d: %s\n",
+        listname, lineno, result.c_str() + close + 1);
+    }
+    result = result.substr(1, close - 1);
+  }
+  if (result.empty()) {
+    fprintf(stderr,
+      "WARNING: empty quoted %s entry at selective instrumentation file line %d matches nothing\n",
+      listname, lineno);
+  }
+  return result;
+}
 
 bool processInstrumentationRequests(const char *fname)
 {
@@ -694,7 +724,6 @@ bool processInstrumentationRequests(const char *fname)
   char line[INBUF_SIZE];
   char* inbuf;
   int lineno = 0;
-  SALT_UNUSED(lineno); // prevent compiler errors
 
 
   if (!input) {
@@ -732,24 +761,7 @@ bool processInstrumentationRequests(const char *fname)
         if (inbuf[0] == '\0') {
           continue;
         }
-        if (inbuf[0] == '"') {
-          /* What if the string begins with "? In that case remove quotes from
-             the string. "#foo" becomes #foo and is passed on to the
-             exclude list. */
-          char *exclude = strdup(&inbuf[1]);
-          for (size_t i = 0; i < strlen(exclude); i++) {
-            if (exclude[i] == '"') {
-              exclude[i]='\0';
-              break; /* out of the loop */
-            }
-          }
-          DPRINT("Passing %s as exclude string\n", exclude);
-          excludelist.push_back(std::string(exclude));
-          free(exclude);
-        }
-        else {
-          excludelist.push_back(std::string(inbuf));
-        }
+        excludelist.push_back(parseListEntry(inbuf, "exclude list", lineno));
       }
     }
 
@@ -768,24 +780,7 @@ bool processInstrumentationRequests(const char *fname)
         if (inbuf[0] == '\0') {
           continue;
         }
-        if (inbuf[0] == '"') {
-          /* What if the string begins with "? In that case remove quotes from
-             the string. "#foo" becomes #foo and is passed on to the
-             exclude list. */
-          char *exclude = strdup(&inbuf[1]);
-          for (size_t i = 0; i < strlen(exclude); i++) {
-            if (exclude[i] == '"') {
-              exclude[i]='\0';
-              break; /* out of the loop */
-            }
-          }
-          DPRINT("Passing %s as include string\n", exclude);
-          includelist.push_back(std::string(exclude));
-          free(exclude);
-        }
-        else {
-          includelist.push_back(std::string(inbuf));
-        }
+        includelist.push_back(parseListEntry(inbuf, "include list", lineno));
       }
     }
 
@@ -804,22 +799,7 @@ bool processInstrumentationRequests(const char *fname)
         if (inbuf[0] == '\0') {
           continue;
         }
-        // strip quotes
-        if (inbuf[0] == '"') {
-          char *include = strdup(&inbuf[1]);
-          for (size_t i = 0; i < strlen(include); i++) {
-            if (include[i] == '"') {
-              include[i] = '\0';
-              break;
-            }
-          }
-          fileincludelist.push_back(std::string(include));
-          free(include);
-        }
-        else {
-          fileincludelist.push_back(std::string(inbuf));
-        }
-	DPRINT("Parsing inst. file: adding %s to file include list\n", inbuf);
+        fileincludelist.push_back(parseListEntry(inbuf, "file include list", lineno));
       }
     }
 
@@ -838,21 +818,7 @@ bool processInstrumentationRequests(const char *fname)
         if (inbuf[0] == '\0') {
           continue;
         }
-        // strip quotes
-        if (inbuf[0] == '"') {
-          char *exclude = strdup(&inbuf[1]);
-          for (size_t i = 0; i < strlen(exclude); i++) {
-            if (exclude[i] == '"') {
-              exclude[i] = '\0';
-              break;
-            }
-          }
-          fileexcludelist.push_back(std::string(exclude));
-          free(exclude);
-        }
-        else {
-          fileexcludelist.push_back(std::string(inbuf));
-        }
+        fileexcludelist.push_back(parseListEntry(inbuf, "file exclude list", lineno));
       }
     }
 

--- a/src/selectfile.cpp
+++ b/src/selectfile.cpp
@@ -727,7 +727,9 @@ bool processInstrumentationRequests(const char *fname)
           break; /* Found the end of exclude list. */
         }
 
-        if ((inbuf[0] == '#') || (inbuf[0] == '\0')) {
+        /* Inside a list block '#' is the wildcard, not a comment marker
+           (issue #64; matches TAU's LLVM plugin). Only blank lines skip. */
+        if (inbuf[0] == '\0') {
           continue;
         }
         if (inbuf[0] == '"') {
@@ -762,7 +764,8 @@ bool processInstrumentationRequests(const char *fname)
       	if (strcmp(inbuf, END_INCLUDE_TOKEN) == 0) {
           break; /* Found the end of exclude list. */
         }
-        if ((inbuf[0] == '#') || (inbuf[0] == '\0')) {
+        /* '#' is the wildcard inside list blocks, not a comment marker. */
+        if (inbuf[0] == '\0') {
           continue;
         }
         if (inbuf[0] == '"') {
@@ -797,7 +800,8 @@ bool processInstrumentationRequests(const char *fname)
       	if (strcmp(inbuf, END_FILE_INCLUDE_TOKEN) == 0) {
           break; /* Found the end of file include list. */
         }
-        if ((inbuf[0] == '#') || (inbuf[0] == '\0')) {
+        /* '#' is the wildcard inside list blocks, not a comment marker. */
+        if (inbuf[0] == '\0') {
           continue;
         }
         // strip quotes
@@ -830,7 +834,8 @@ bool processInstrumentationRequests(const char *fname)
       	if (strcmp(inbuf, END_FILE_EXCLUDE_TOKEN) == 0) {
           break; /* Found the end of file exclude list. */
         }
-        if ((inbuf[0] == '#') || (inbuf[0] == '\0')) {
+        /* '#' is the wildcard inside list blocks, not a comment marker. */
+        if (inbuf[0] == '\0') {
           continue;
         }
         // strip quotes

--- a/tests/sif/exclude_c.tau
+++ b/tests/sif/exclude_c.tau
@@ -1,8 +1,8 @@
 # SIF: exclude excluded_routine from C instrumentation.
 # C/C++ matcher uses regex_match against the full timer signature
 # (e.g., "void excluded_routine()") so a "#wildcard#" pattern is needed.
-# The leading "#" of the pattern is a line-comment marker, so the entry
-# must be quoted to be parsed as a wildcard rather than a comment.
+# Quoting is optional since issue #64 ('#' only starts a comment outside
+# list blocks); the quoted form is kept here to lock PDT-style support.
 BEGIN_EXCLUDE_LIST
 "#excluded_routine#"
 END_EXCLUDE_LIST

--- a/tests/sif/exclude_cpp.tau
+++ b/tests/sif/exclude_cpp.tau
@@ -1,5 +1,5 @@
 # SIF: exclude excluded_routine from C++ instrumentation.
-# See exclude_c.tau for notes on the wildcard/quoting requirement.
+# See exclude_c.tau for notes on wildcards and optional quoting.
 BEGIN_EXCLUDE_LIST
 "#excluded_routine#"
 END_EXCLUDE_LIST

--- a/tests/sif/exclude_empty_quote_cpp.tau
+++ b/tests/sif/exclude_empty_quote_cpp.tau
@@ -1,0 +1,6 @@
+# A lone quote parses to an empty pattern that can never match a routine.
+# It is accepted (lenient, TAU-compatible) but must trigger a warning; both
+# routines keep their timers.
+BEGIN_EXCLUDE_LIST
+"
+END_EXCLUDE_LIST

--- a/tests/sif/exclude_quote_trailing_junk_cpp.tau
+++ b/tests/sif/exclude_quote_trailing_junk_cpp.tau
@@ -1,0 +1,6 @@
+# A quoted entry with stray text after the closing quote. The text is ignored
+# (pattern ends at the closing quote, TAU-compatible), but the instrumentor
+# must warn that part of the line was dropped.
+BEGIN_EXCLUDE_LIST
+"#noinst#"junk
+END_EXCLUDE_LIST

--- a/tests/sif/exclude_unclosed_quote_cpp.tau
+++ b/tests/sif/exclude_unclosed_quote_cpp.tau
@@ -1,0 +1,6 @@
+# A quoted entry whose closing quote is missing. Parsing stays lenient for
+# TAU compatibility (pattern is everything after the opening quote), but the
+# instrumentor must warn the user about the unterminated quote.
+BEGIN_EXCLUDE_LIST
+"#noinst#
+END_EXCLUDE_LIST

--- a/tests/sif/exclude_unquoted_wildcard_prefix_cpp.tau
+++ b/tests/sif/exclude_unquoted_wildcard_prefix_cpp.tau
@@ -1,0 +1,8 @@
+# Issue #64 reproducer: a routine exclude pattern that STARTS with the '#'
+# wildcard, written WITHOUT surrounding quotes. TAU's LLVM plugin treats every
+# non-blank line inside a BEGIN_/END_ list as an entry, so SALT must parse the
+# line below as a pattern, not a comment. (Comments like these, outside the
+# list, are still comments.)
+BEGIN_EXCLUDE_LIST
+#noinst#
+END_EXCLUDE_LIST

--- a/tests/sif/exclude_unquoted_wildcard_routine_f90.tau
+++ b/tests/sif/exclude_unquoted_wildcard_routine_f90.tau
@@ -1,0 +1,6 @@
+# Same as exclude_wildcard_routine_f90.tau but with the pattern unquoted:
+# a leading-# wildcard inside a list block is a pattern, not a comment
+# (issue #64). Both subprograms lose their timers.
+BEGIN_EXCLUDE_LIST
+#routine
+END_EXCLUDE_LIST

--- a/tests/sif/exclude_wildcard_routine_f90.tau
+++ b/tests/sif/exclude_wildcard_routine_f90.tau
@@ -1,6 +1,7 @@
 # Wildcard "#routine" should match both keep_routine and excluded_routine
 # (kleene-star # at the front matches the leading prefix).
-# The pattern is quoted because '#' at column 0 is the SIF comment marker.
+# Quoting is optional since issue #64; quoted form kept to lock PDT-style
+# support (unquoted coverage lives in the *_unquoted_* tests).
 BEGIN_EXCLUDE_LIST
 "#routine"
 END_EXCLUDE_LIST

--- a/tests/sif/include_unquoted_wildcard_f90.tau
+++ b/tests/sif/include_unquoted_wildcard_f90.tau
@@ -1,5 +1,5 @@
-# Unquoted twin of include_wildcard_exclude_specific_f90.tau (issue #64
-# applies to every list kind): "#routine" whitelists both subprograms, the
+# Unquoted twin of include_wildcard_exclude_specific_f90.tau; issue #64
+# applies to every list kind. "#routine" whitelists both subprograms, the
 # exclude list pulls excluded_routine back out. Only keep_routine keeps its
 # timer. Include-list whitelisting exists only in the Fortran frontend.
 BEGIN_INCLUDE_LIST

--- a/tests/sif/include_unquoted_wildcard_f90.tau
+++ b/tests/sif/include_unquoted_wildcard_f90.tau
@@ -1,0 +1,10 @@
+# Unquoted twin of include_wildcard_exclude_specific_f90.tau (issue #64
+# applies to every list kind): "#routine" whitelists both subprograms, the
+# exclude list pulls excluded_routine back out. Only keep_routine keeps its
+# timer. Include-list whitelisting exists only in the Fortran frontend.
+BEGIN_INCLUDE_LIST
+#routine
+END_INCLUDE_LIST
+BEGIN_EXCLUDE_LIST
+excluded_routine
+END_EXCLUDE_LIST

--- a/tests/sif_excl_wildcard_prefix.cpp
+++ b/tests/sif_excl_wildcard_prefix.cpp
@@ -1,7 +1,7 @@
 // Reproducer for https://github.com/ParaToolsInc/salt-fm/issues/64
 // (contributed by @giltirn): dosomething_noinst is excluded via the
 // leading-wildcard pattern #noinst# in the companion SIF file.
-#include <iostream>
+#include <cstdio>
 
 #include<thread>
 #include<chrono>

--- a/tests/sif_excl_wildcard_prefix.cpp
+++ b/tests/sif_excl_wildcard_prefix.cpp
@@ -1,0 +1,27 @@
+// Reproducer for https://github.com/ParaToolsInc/salt-fm/issues/64
+// (contributed by @giltirn): dosomething_noinst is excluded via the
+// leading-wildcard pattern #noinst# in the companion SIF file.
+#include <iostream>
+
+#include<thread>
+#include<chrono>
+
+void dosomething_inst(){
+  for(int i=0;i<5;i++){
+    printf("%d\n",i);
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+  }
+}
+
+void dosomething_noinst(){
+  for(int i=0;i<5;i++){
+    printf("%d\n",i);
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+  }
+}
+
+int main(void){
+  dosomething_inst();
+  dosomething_noinst();
+  return 0;
+}


### PR DESCRIPTION
Unquoted patterns starting with the # wildcard (e.g. `#noinst#`) inside BEGIN_/END_ list blocks were eaten as comments. Now only lines outside list blocks are comments, same as TAU's LLVM plugin. Quoted forms still work. Also warns on sketchy quoting (unclosed quote, junk after closing quote, empty pattern) instead of silently mangling the entry. Tests for all of it, committed red first.

Fixes #64