### PR TITLE
Generate fabricated types for unknown namespaces, class templates, qualified types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1247,12 +1247,12 @@ add_fabricate_test(multi_param fabricate_multi_param.cpp ON
   "test4[(]n1::t1<int>, n2::t2<char>[)]")
 add_fabricate_test(case2 fabricate_case2.cpp ON
   "int test[(]int[)]" ""
-  "SALT: fabricated 0 namespaces, 0 class templates")
+  "Fabricated 0 namespaces, 0 class templates")
 add_fabricate_test(case3 fabricate_case3.cpp ON
   "int test[(]float, testns::lemur<int>[)]")
 add_fabricate_test(reuse fabricate_reuse.cpp ON
   "int first[(]testns::lemur<int>[)]" ""
-  "SALT: fabricated 1 namespaces, 1 class templates")
+  "Fabricated 1 namespaces, 1 class templates")
 
 add_test(NAME check_fabricate_reuse_second
   COMMAND ${CMAKE_COMMAND} -E cat ./reuse.fab.inst.cpp
@@ -1265,7 +1265,22 @@ set_tests_properties(check_fabricate_reuse_second
 )
 
 add_fabricate_test(plain_qualified fabricate_plain_qualified.cpp ON
-  "int test[(]int[)]")
+  "int test[(]testns::Foo[)]" ""
+  "Fabricated 1 namespaces, 0 class templates, 1 records")
+
+add_fabricate_test(mixed_kinds fabricate_mixed_kinds.cpp ON
+  "int usesPlain[(]testns::Foo[)]" ""
+  "Fabricated 1 namespaces, 1 class templates, 1 records")
+
+add_test(NAME check_fabricate_mixed_kinds_template
+  COMMAND ${CMAKE_COMMAND} -E cat ./mixed_kinds.fab.inst.cpp
+)
+set_tests_properties(check_fabricate_mixed_kinds_template
+  PROPERTIES
+  DEPENDS instrument_fabricate_mixed_kinds
+  LABELS "lang:CXX;phase:check;fabricate"
+  PASS_REGULAR_EXPRESSION "int usesTemplate[(]testns::lemur<int>[)]"
+)
 add_fabricate_test(nontype_args fabricate_nontype_args.cpp ON
   "int test[(]int[)]")
 add_fabricate_test(member_def fabricate_member_def.cpp ON
@@ -1283,15 +1298,15 @@ set_tests_properties(check_fabricate_member_def_ctor
 
 add_fabricate_test(class_member fabricate_class_member.cpp ON
   "int f[(]int[)]" ""
-  "SALT: fabricated 0 namespaces, 0 class templates")
+  "Fabricated 0 namespaces, 0 class templates")
 add_fabricate_test(control_on fabricate_control.cpp ON
   "int add[(]int, int[)]" ""
-  "SALT: fabricated 0 namespaces, 0 class templates")
+  "Fabricated 0 namespaces, 0 class templates")
 add_fabricate_test(control_off fabricate_control.cpp OFF
   "int add[(]int, int[)]")
 add_fabricate_test(c_control fabricate_control.c ON
   "int add[(]int, int[)]" ""
-  "SALT: fabricated 0 namespaces, 0 class templates")
+  "Fabricated 0 namespaces, 0 class templates")
 add_fabricate_test(canary fabricate_case1.cpp OFF
   "int test" "TAU_PROFILE_TIMER[^\n]*int test[(]")
 
@@ -1306,7 +1321,7 @@ set_tests_properties(instrument_fabricate_env
   ENVIRONMENT "SALT_FABRICATE_UNKNOWN_TYPES=1"
   LABELS "lang:CXX;phase:instrument;fabricate"
   PASS_REGULAR_EXPRESSION
-    "SALT: fabricated [0-9]+ namespaces, [0-9]+ class templates"
+    "Fabricated [0-9]+ namespaces, [0-9]+ class templates"
 )
 add_test(NAME check_fabricate_env
   COMMAND ${CMAKE_COMMAND} -E cat ./env.fab.inst.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -419,6 +419,7 @@ set(SALT_HEADER_FILES
   ryml_all.hpp
   selectfile.hpp
   instrumentor.hpp
+  sema_fabricator.hpp
 )
 
 list(TRANSFORM SALT_HEADER_FILES PREPEND "${CMAKE_SOURCE_DIR}/include/")
@@ -439,6 +440,7 @@ set(CPARSE_LLVM_SRCS
   frontend.cpp
   instrumentor.cpp
   selectfile.cpp
+  sema_fabricator.cpp
 )
 
 list(TRANSFORM CPARSE_LLVM_SRCS PREPEND "${CMAKE_SOURCE_DIR}/src/")
@@ -1182,6 +1184,139 @@ if(TEST_FORTRAN)
     FAIL_REGULAR_EXPRESSION "${_sif_excluded_pattern_fortran}"
   )
 endif()
+
+# Fabrication tests (--tau_fabricate_unknown_types):
+function(add_fabricate_test name src with_flag pass_regex)
+  set(fail_regex "")
+  set(summary_regex
+      "Fabricated [0-9]+ namespaces, [0-9]+ class templates")
+  if(ARGC GREATER 4)
+    set(fail_regex "${ARGV4}")
+  endif()
+  if(ARGC GREATER 5)
+    set(summary_regex "${ARGV5}")
+  endif()
+  get_filename_component(_src_ext ${src} EXT)
+  set(out_file ${name}.fab.inst${_src_ext})
+  _salt_ext_to_label(${src} _lang_label)
+  if(with_flag)
+    set(flag_args --tau_fabricate_unknown_types)
+    set(instrument_pass_pattern "${summary_regex}")
+  else()
+    set(flag_args "")
+    set(instrument_pass_pattern "[Ii]nstrumentation:")
+  endif()
+  add_test(NAME instrument_fabricate_${name}
+    COMMAND ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}/saltfm
+            ${flag_args}
+            --tau_output=${out_file}
+            ${CMAKE_SOURCE_DIR}/tests/${src}
+  )
+  set_tests_properties(instrument_fabricate_${name}
+    PROPERTIES
+    REQUIRED_FILES "${CMAKE_SOURCE_DIR}/tests/${src}"
+    ENVIRONMENT "SALT_FABRICATE_UNKNOWN_TYPES=0"
+    LABELS "${_lang_label};phase:instrument;fabricate"
+    PASS_REGULAR_EXPRESSION "${instrument_pass_pattern}"
+  )
+  add_test(NAME check_fabricate_${name}
+    COMMAND ${CMAKE_COMMAND} -E cat ./${out_file}
+  )
+  set_tests_properties(check_fabricate_${name}
+    PROPERTIES
+    DEPENDS instrument_fabricate_${name}
+    ENVIRONMENT "SALT_FABRICATE_UNKNOWN_TYPES=0"
+    LABELS "${_lang_label};phase:check;fabricate"
+    PASS_REGULAR_EXPRESSION "${pass_regex}"
+  )
+  if(NOT fail_regex STREQUAL "")
+    set_tests_properties(check_fabricate_${name}
+      PROPERTIES
+      FAIL_REGULAR_EXPRESSION "${fail_regex}"
+    )
+  endif()
+endfunction()
+
+add_fabricate_test(case1 fabricate_case1.cpp ON
+  "int test[(]testns::lemur<int>[)]")
+add_fabricate_test(nested_ns fabricate_nested_ns.cpp ON
+  "test2[(]aa::bb::cc<int>[)]")
+add_fabricate_test(return_type fabricate_return_type.cpp ON
+  "qq::rr<float> test3[(]int[)]")
+add_fabricate_test(multi_param fabricate_multi_param.cpp ON
+  "test4[(]n1::t1<int>, n2::t2<char>[)]")
+add_fabricate_test(case2 fabricate_case2.cpp ON
+  "int test[(]int[)]" ""
+  "SALT: fabricated 0 namespaces, 0 class templates")
+add_fabricate_test(case3 fabricate_case3.cpp ON
+  "int test[(]float, testns::lemur<int>[)]")
+add_fabricate_test(reuse fabricate_reuse.cpp ON
+  "int first[(]testns::lemur<int>[)]" ""
+  "SALT: fabricated 1 namespaces, 1 class templates")
+
+add_test(NAME check_fabricate_reuse_second
+  COMMAND ${CMAKE_COMMAND} -E cat ./reuse.fab.inst.cpp
+)
+set_tests_properties(check_fabricate_reuse_second
+  PROPERTIES
+  DEPENDS instrument_fabricate_reuse
+  LABELS "lang:CXX;phase:check;fabricate"
+  PASS_REGULAR_EXPRESSION "int second[(]testns::lemur<int>[)]"
+)
+
+add_fabricate_test(plain_qualified fabricate_plain_qualified.cpp ON
+  "int test[(]int[)]")
+add_fabricate_test(nontype_args fabricate_nontype_args.cpp ON
+  "int test[(]int[)]")
+add_fabricate_test(member_def fabricate_member_def.cpp ON
+  "void MyClass::method[(]void[)]")
+
+add_test(NAME check_fabricate_member_def_ctor
+  COMMAND ${CMAKE_COMMAND} -E cat ./member_def.fab.inst.cpp
+)
+set_tests_properties(check_fabricate_member_def_ctor
+  PROPERTIES
+  DEPENDS instrument_fabricate_member_def
+  LABELS "lang:CXX;phase:check;fabricate"
+  PASS_REGULAR_EXPRESSION "int MyClass::MyClass[(]void[)]"
+)
+
+add_fabricate_test(class_member fabricate_class_member.cpp ON
+  "int f[(]int[)]" ""
+  "SALT: fabricated 0 namespaces, 0 class templates")
+add_fabricate_test(control_on fabricate_control.cpp ON
+  "int add[(]int, int[)]" ""
+  "SALT: fabricated 0 namespaces, 0 class templates")
+add_fabricate_test(control_off fabricate_control.cpp OFF
+  "int add[(]int, int[)]")
+add_fabricate_test(c_control fabricate_control.c ON
+  "int add[(]int, int[)]" ""
+  "SALT: fabricated 0 namespaces, 0 class templates")
+add_fabricate_test(canary fabricate_case1.cpp OFF
+  "int test" "TAU_PROFILE_TIMER[^\n]*int test[(]")
+
+add_test(NAME instrument_fabricate_env
+  COMMAND ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}/saltfm
+          --tau_output=env.fab.inst.cpp
+          ${CMAKE_SOURCE_DIR}/tests/fabricate_case1.cpp
+)
+set_tests_properties(instrument_fabricate_env
+  PROPERTIES
+  REQUIRED_FILES "${CMAKE_SOURCE_DIR}/tests/fabricate_case1.cpp"
+  ENVIRONMENT "SALT_FABRICATE_UNKNOWN_TYPES=1"
+  LABELS "lang:CXX;phase:instrument;fabricate"
+  PASS_REGULAR_EXPRESSION
+    "SALT: fabricated [0-9]+ namespaces, [0-9]+ class templates"
+)
+add_test(NAME check_fabricate_env
+  COMMAND ${CMAKE_COMMAND} -E cat ./env.fab.inst.cpp
+)
+set_tests_properties(check_fabricate_env
+  PROPERTIES
+  DEPENDS instrument_fabricate_env
+  LABELS "lang:CXX;phase:check;fabricate"
+  PASS_REGULAR_EXPRESSION "int test[(]testns::lemur<int>[)]"
+)
 
 set(SALT_COMPILERS_TO_TEST gcc clang)
 # Per-toolchain build subdirs (GCC, LLVM) shared by C/C++ and Fortran tests.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1246,7 +1246,7 @@ add_fabricate_test(return_type fabricate_return_type.cpp ON
 add_fabricate_test(multi_param fabricate_multi_param.cpp ON
   "test4[(]n1::t1<int>, n2::t2<char>[)]")
 add_fabricate_test(case2 fabricate_case2.cpp ON
-  "int test[(]int[)]" ""
+  "int test[(]lemur<int>[)]" ""
   "Fabricated 0 namespaces, 0 class templates")
 add_fabricate_test(case3 fabricate_case3.cpp ON
   "int test[(]float, testns::lemur<int>[)]")
@@ -1281,8 +1281,9 @@ set_tests_properties(check_fabricate_mixed_kinds_template
   LABELS "lang:CXX;phase:check;fabricate"
   PASS_REGULAR_EXPRESSION "int usesTemplate[(]testns::lemur<int>[)]"
 )
+
 add_fabricate_test(nontype_args fabricate_nontype_args.cpp ON
-  "int test[(]int[)]")
+  "int test[(]testns::arr<int, 3>[)]")
 add_fabricate_test(member_def fabricate_member_def.cpp ON
   "void MyClass::method[(]void[)]")
 
@@ -1297,7 +1298,7 @@ set_tests_properties(check_fabricate_member_def_ctor
 )
 
 add_fabricate_test(class_member fabricate_class_member.cpp ON
-  "int f[(]int[)]" ""
+  "int f[(]Real::Unknown[)]" ""
   "Fabricated 0 namespaces, 0 class templates")
 add_fabricate_test(control_on fabricate_control.cpp ON
   "int add[(]int, int[)]" ""
@@ -1332,6 +1333,22 @@ set_tests_properties(check_fabricate_env
   LABELS "lang:CXX;phase:check;fabricate"
   PASS_REGULAR_EXPRESSION "int test[(]testns::lemur<int>[)]"
 )
+
+add_fabricate_test(srctext_zmobius fabricate_srctext_zmobius.cpp ON
+  "void computeZmobiusOmega[(]std::vector<ComplexD> &, const int, \
+const std::vector<RealD> &, const int, const RealD[)]")
+add_fabricate_test(srctext_default_arg fabricate_srctext_default_arg.cpp ON
+  "void withDefault[(]testns::tmpl<int>[)]"
+  "TAU_PROFILE_TIMER[^\n]*tmpl<int> *=")
+add_fabricate_test(srctext_fallback fabricate_srctext_fallback.cpp ON
+  "void fallbackUnnamed[(]int[)]")
+add_fabricate_test(srctext_comment fabricate_srctext_comment.cpp ON
+  "void commented[(]std::vector<RealD> &[)]"
+  "TAU_PROFILE_TIMER[^\n]*holds")
+add_fabricate_test(srctext_multiline fabricate_srctext_multiline.cpp ON
+  "void multiline[(]std::vector< RealD> &, const int[)]")
+add_fabricate_test(srctext_fn_template fabricate_srctext_fn_template.cpp ON
+  "void tmplFn[(]std::vector<RealD> &, T[)]")
 
 set(SALT_COMPILERS_TO_TEST gcc clang)
 # Per-toolchain build subdirs (GCC, LLVM) shared by C/C++ and Fortran tests.

--- a/include/instrumentor.hpp
+++ b/include/instrumentor.hpp
@@ -35,6 +35,8 @@ extern llvm::cl::opt<bool> do_inline;
 
 extern llvm::cl::opt<std::string> selectfile;
 
+extern llvm::cl::opt<bool> fabricate_unknown_types;
+
 typedef struct inst_loc {
     int line = -1;
     int col = -1;

--- a/include/sema_fabricator.hpp
+++ b/include/sema_fabricator.hpp
@@ -1,0 +1,42 @@
+#ifndef SEMA_FABRICATOR_HPP
+#define SEMA_FABRICATOR_HPP
+
+#include "clang/Sema/ExternalSemaSource.h"
+#include "clang/Sema/TypoCorrection.h"
+
+namespace salt
+{
+
+// An ExternalSemaSource that fabricates declarations for unknown qualified names during parsing
+class SaltSemaFabricator : public clang::ExternalSemaSource
+{
+public:
+    void InitializeSema(clang::Sema &S) override;
+
+    clang::TypoCorrection CorrectTypo(const clang::DeclarationNameInfo &Typo,
+                                      int LookupKind, clang::Scope *S,
+                                      clang::CXXScopeSpec *SS,
+                                      clang::CorrectionCandidateCallback &CCC,
+                                      clang::DeclContext *MemberContext,
+                                      bool EnteringContext,
+                                      const clang::ObjCObjectPointerType *OPT) override;
+
+    unsigned numNamespaces() const { return num_namespaces; }
+    unsigned numTemplates() const { return num_templates; }
+
+private:
+    clang::NamedDecl *findExisting(clang::DeclContext *DC,
+                                   clang::IdentifierInfo *II);
+    clang::NamespaceDecl *fabricateNamespace(clang::DeclContext *DC,
+                                             clang::IdentifierInfo *II);
+    clang::ClassTemplateDecl *fabricateClassTemplate(clang::DeclContext *DC,
+                                                     clang::IdentifierInfo *II);
+
+    clang::Sema *sema = nullptr;
+    unsigned num_namespaces = 0;
+    unsigned num_templates = 0;
+};
+
+} // namespace salt
+
+#endif

--- a/include/sema_fabricator.hpp
+++ b/include/sema_fabricator.hpp
@@ -23,6 +23,7 @@ public:
 
     unsigned numNamespaces() const { return num_namespaces; }
     unsigned numTemplates() const { return num_templates; }
+    unsigned numRecords() const { return num_records; }
 
 private:
     clang::NamedDecl *findExisting(clang::DeclContext *DC,
@@ -31,10 +32,13 @@ private:
                                              clang::IdentifierInfo *II);
     clang::ClassTemplateDecl *fabricateClassTemplate(clang::DeclContext *DC,
                                                      clang::IdentifierInfo *II);
+    clang::CXXRecordDecl *fabricateRecord(clang::DeclContext *DC,
+                                          clang::IdentifierInfo *II);
 
     clang::Sema *sema = nullptr;
     unsigned num_namespaces = 0;
     unsigned num_templates = 0;
+    unsigned num_records = 0;
 };
 
 } // namespace salt

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -91,6 +91,21 @@ llvm::cl::opt<std::string> selectfile("tau_select_file",
                                       llvm::cl::desc("Provide a selective instrumentation specification file"),
                                       llvm::cl::value_desc("filename"), llvm::cl::cat(MyToolCategory));
 
+static bool getEnvFabricateDefault() {
+    const char *val = getenv("SALT_FABRICATE_UNKNOWN_TYPES");
+    if (val == nullptr) {
+        return false;
+    }
+    std::string s(val);
+    std::transform(s.begin(), s.end(), s.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    return !(s.empty() || s == "0" || s == "false" || s == "no" || s == "off");
+}
+
+llvm::cl::opt<bool> fabricate_unknown_types("tau_fabricate_unknown_types",
+                                            llvm::cl::desc("Fabricate declarations for unknown qualified C++ names."),
+                                            llvm::cl::init(getEnvFabricateDefault()), llvm::cl::cat(MyToolCategory));
+
 #include "clang_header_includes.h"
 
 char **addHeadersToCommand(int *argc, const char **argv)

--- a/src/instrumentor.cpp
+++ b/src/instrumentor.cpp
@@ -14,6 +14,7 @@
 #include "clang/Basic/SourceManager.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/FrontendAction.h"
+#include "clang/Lex/Lexer.h"
 #include "clang/Parse/ParseAST.h"
 #include "clang/Sema/Sema.h"
 #include "clang/Tooling/CommonOptionsParser.h"
@@ -24,6 +25,7 @@
 #include <cstring>
 #include <fstream>
 #include <iostream>
+#include <optional>
 #include <regex>
 #include <string>
 #include <vector>
@@ -435,6 +437,249 @@ bool check_file_against_list(std::list<std::string> list, std::string fname)
 }
 
 
+// Strip the elaborations the semantic type printer introduces
+static std::string cleanSemanticTypeName(std::string name)
+{
+    while (name.find("class ") != std::string::npos)
+    {
+        name.erase(name.find("class "), 6);
+    }
+    while (name.find("enum ") != std::string::npos)
+    {
+        name.erase(name.find("enum "), 5);
+    }
+    while (name.find("_Bool") != std::string::npos)
+    {
+        name.replace(name.find("_Bool"), 5, "bool");
+    }
+    return name;
+}
+
+// Extract the raw source text of a declarator with its name token spliced out
+static std::optional<std::string> extractDeclaratorText(SourceRange range,
+                                                        SourceLocation name_loc,
+                                                        SourceLocation cut_loc,
+                                                        const SourceManager &src_mgr,
+                                                        const LangOptions &lang_opts)
+{
+    if (range.isInvalid())
+    {
+        return std::nullopt;
+    }
+    bool failed = false;
+    auto charText = [&](SourceLocation begin, SourceLocation end) -> std::string
+    {
+        bool invalid = false;
+        llvm::StringRef text = Lexer::getSourceText(
+            CharSourceRange::getCharRange(begin, end), src_mgr, lang_opts, &invalid);
+        failed = failed || invalid;
+        return text.str();
+    };
+    SourceLocation end_loc = cut_loc.isValid()
+                                 ? cut_loc
+                                 : Lexer::getLocForEndOfToken(range.getEnd(), 0, src_mgr, lang_opts);
+    if (end_loc.isInvalid())
+    {
+        return std::nullopt;
+    }
+    std::string raw;
+    if (name_loc.isInvalid())
+    {
+        raw = charText(range.getBegin(), end_loc);
+    }
+    else
+    {
+        raw = charText(range.getBegin(), name_loc);
+        SourceLocation after_name = Lexer::getLocForEndOfToken(name_loc, 0, src_mgr, lang_opts);
+        if (after_name.isValid() && src_mgr.isBeforeInTranslationUnit(after_name, end_loc))
+        {
+            raw += charText(after_name, end_loc);
+        }
+    }
+    if (failed)
+    {
+        return std::nullopt;
+    }
+    return raw;
+}
+
+// Strip comments to remove comments inline in function declaration
+static std::string stripComments(const std::string &text)
+{
+    std::string result;
+    for (size_t i = 0; i < text.size();)
+    {
+        if (text[i] == '/' && i + 1 < text.size() && text[i + 1] == '*')
+        {
+            size_t end = text.find("*/", i + 2);
+            i = (end == std::string::npos) ? text.size() : end + 2;
+            result += ' ';
+            continue;
+        }
+        if (text[i] == '/' && i + 1 < text.size() && text[i + 1] == '/')
+        {
+            size_t end = text.find('\n', i + 2);
+            i = (end == std::string::npos) ? text.size() : end;
+            result += ' ';
+            continue;
+        }
+        result += text[i++];
+    }
+    return result;
+}
+
+// Collapse whitespace runs to single spaces
+static std::string collapseWhitespace(const std::string &text)
+{
+    std::string result;
+    bool in_whitespace = false;
+    for (char c : text)
+    {
+        if (c == ' ' || c == '\t' || c == '\n' || c == '\r')
+        {
+            in_whitespace = true;
+            continue;
+        }
+        if (in_whitespace && !result.empty())
+        {
+            result += ' ';
+        }
+        in_whitespace = false;
+        result += c;
+    }
+    return result;
+}
+
+// Escape '\' and '"' so the text can be embedded in generated TAU_PROFILE_TIMER("...") string literal.
+static std::string escapeForStringLiteral(const std::string &text)
+{
+    std::string result;
+    for (char c : text)
+    {
+        if (c == '\\' || c == '"')
+        {
+            result += '\\';
+        }
+        result += c;
+    }
+    return result;
+}
+
+// Reconstruct the source-spelled text of a declarator's type
+static std::optional<std::string> spelledTypeText(SourceRange range,
+                                                  SourceLocation name_loc,
+                                                  SourceLocation cut_loc,
+                                                  const SourceManager &src_mgr,
+                                                  const LangOptions &lang_opts)
+{
+    std::optional<std::string> raw =
+        extractDeclaratorText(range, name_loc, cut_loc, src_mgr, lang_opts);
+    if (!raw)
+    {
+        return std::nullopt;
+    }
+    std::string clean = collapseWhitespace(stripComments(*raw));
+    // Drop a trailing '=' left over from a removed default argument
+    while (!clean.empty() && (clean.back() == '=' || clean.back() == ' '))
+    {
+        clean.pop_back();
+    }
+    if (clean.empty())
+    {
+        return std::nullopt;
+    }
+    return escapeForStringLiteral(clean);
+}
+
+static std::optional<std::string> spelledParamType(const ParmVarDecl *param,
+                                                   const SourceManager &src_mgr,
+                                                   const LangOptions &lang_opts)
+{
+    SourceLocation name_loc;
+    if (!param->getDeclName().isEmpty())
+    {
+        name_loc = param->getLocation();
+    }
+    SourceLocation cut_loc;
+    if (param->hasDefaultArg() || param->hasUnparsedDefaultArg() ||
+        param->hasUninstantiatedDefaultArg())
+    {
+        SourceRange default_range = param->getDefaultArgRange();
+        if (default_range.isValid())
+        {
+            cut_loc = default_range.getBegin();
+        }
+    }
+    return spelledTypeText(param->getSourceRange(), name_loc, cut_loc, src_mgr, lang_opts);
+}
+
+static std::string spelledOrSemantic(std::optional<std::string> spelled, QualType semantic)
+{
+    if (spelled && !spelled->empty())
+    {
+        return *spelled;
+    }
+    return cleanSemanticTypeName(semantic.getAsString());
+}
+
+// Assemble a signature using spelled text for the return type
+// when the function is invalid and for each
+// parameter that is invalid or belongs to an invalid function.
+static std::string spelledSignature(FunctionDecl *func, SourceManager &src_mgr,
+                                    const LangOptions &lang_opts)
+{
+    const bool func_invalid = func->isInvalidDecl();
+    std::string ret_str = spelledOrSemantic(
+        func_invalid ? spelledTypeText(func->getReturnTypeSourceRange(), SourceLocation(),
+                                       SourceLocation(), src_mgr, lang_opts)
+                     : std::nullopt,
+        func->getReturnType());
+    std::string params;
+    for (const ParmVarDecl *param : func->parameters())
+    {
+        if (!params.empty())
+        {
+            params += ", ";
+        }
+        params += spelledOrSemantic((func_invalid || param->isInvalidDecl())
+                                        ? spelledParamType(param, src_mgr, lang_opts)
+                                        : std::nullopt,
+                                    param->getType());
+    }
+    if (params.empty())
+    {
+        params = func->isVariadic() ? "..." : "void";
+    }
+    else if (func->isVariadic())
+    {
+        params += ", ...";
+    }
+    const char *sep = (!ret_str.empty() && (ret_str.back() == '*' || ret_str.back() == '&'))
+                          ? ""
+                          : " ";
+    return ret_str + sep + "(" + params + ")";
+}
+
+static bool useSpelledSignature(const FunctionDecl *func)
+{
+    if (!fabricate_unknown_types)
+    {
+        return false;
+    }
+    if (func->isInvalidDecl())
+    {
+        return true;
+    }
+    for (const ParmVarDecl *param : func->parameters())
+    {
+        if (param->isInvalidDecl())
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
 void makeFuncAndTimerNames(FunctionDecl *func, ASTContext *context, SourceManager &src_mgr, std::string &func_name,
                          std::string &timer_name)
 {
@@ -456,23 +701,31 @@ void makeFuncAndTimerNames(FunctionDecl *func, ASTContext *context, SourceManage
 
     func_name = func->getQualifiedNameAsString();
     QualType type = func->getType();
-    std::string sig = type.getAsString();
-    while (sig.find("class ") != std::string::npos)
+    std::string sig;
+    if (useSpelledSignature(func))
     {
-        sig.erase(sig.find("class "), 6);
+        sig = spelledSignature(func, src_mgr, context->getLangOpts());
     }
-    while (sig.find("enum ") != std::string::npos)
+    else
     {
-        sig.erase(sig.find("enum "), 5);
-    }
-    // not sure we need this yet
-    // while (sig.find("struct ") != std::string::npos) {
-    //     sig.erase(sig.find("struct "), 7);
-    // }
-    while (sig.find("_Bool") != std::string::npos)
-    {
-        // printf("%s\n", sig.c_str());
-        sig.replace(sig.find("_Bool"), 5, "bool");
+        sig = type.getAsString();
+        while (sig.find("class ") != std::string::npos)
+        {
+            sig.erase(sig.find("class "), 6);
+        }
+        while (sig.find("enum ") != std::string::npos)
+        {
+            sig.erase(sig.find("enum "), 5);
+        }
+        // not sure we need this yet
+        // while (sig.find("struct ") != std::string::npos) {
+        //     sig.erase(sig.find("struct "), 7);
+        // }
+        while (sig.find("_Bool") != std::string::npos)
+        {
+            // printf("%s\n", sig.c_str());
+            sig.replace(sig.find("_Bool"), 5, "bool");
+        }
     }
     sig.insert(sig.find_first_of("("), func_name);
 

--- a/src/instrumentor.cpp
+++ b/src/instrumentor.cpp
@@ -815,7 +815,8 @@ class FindFunctionAction : public ASTFrontendAction
                  CI.getFrontendOpts().SkipFunctionBodies);
         llvm::outs() << "Fabricated " << fabricator->numNamespaces()
                      << " namespaces, " << fabricator->numTemplates()
-                     << " class templates\n";
+                     << " class templates, " << fabricator->numRecords()
+                     << " records\n";
     }
 
   private:

--- a/src/instrumentor.cpp
+++ b/src/instrumentor.cpp
@@ -14,7 +14,11 @@
 #include "clang/Basic/SourceManager.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/FrontendAction.h"
+#include "clang/Parse/ParseAST.h"
+#include "clang/Sema/Sema.h"
 #include "clang/Tooling/CommonOptionsParser.h"
+#include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include "llvm/Config/llvm-config.h"
 #include <algorithm>
 #include <cctype>
 #include <cstring>
@@ -27,6 +31,7 @@
 
 #include "dprint.hpp"
 #include "selectfile.hpp"
+#include "sema_fabricator.hpp"
 
 using namespace clang;
 
@@ -565,7 +570,10 @@ class FindReturnVisitor : public RecursiveASTVisitor<FindReturnVisitor>
         if (encl_function->getReturnType()->isClassType())
         {
             CXXRecordDecl *decl = encl_function->getReturnType()->getAsCXXRecordDecl();
-            if (!(decl->hasSimpleCopyAssignment() || decl->hasTrivialCopyAssignment()))
+            // Check whether there's actually a definition.
+            // A fabricated type won't have one.
+            if (decl != nullptr && decl->hasDefinition() &&
+                !(decl->hasSimpleCopyAssignment() || decl->hasTrivialCopyAssignment()))
             {
                 needs_move = true;
             }
@@ -667,7 +675,10 @@ class FindFunctionVisitor : public RecursiveASTVisitor<FindFunctionVisitor>
         if (func->getReturnType()->isClassType())
         {
             CXXRecordDecl *decl = func->getReturnType()->getAsCXXRecordDecl();
-            if (!(decl->hasSimpleCopyAssignment() || decl->hasTrivialCopyAssignment()))
+            // Check whether there's actually a definition.
+            // A fabricated type won't have one.
+            if (decl != nullptr && decl->hasDefinition() &&
+                !(decl->hasSimpleCopyAssignment() || decl->hasTrivialCopyAssignment()))
             {
                 needs_move = true;
             }
@@ -718,6 +729,11 @@ class FindFunctionConsumer : public clang::ASTConsumer
         auto decls = context.getTranslationUnitDecl()->decls();
         for (auto &decl : decls)
         {
+            // Implicit decls don't have source locations
+            if (decl->isImplicit())
+            {
+                continue;
+            }
             SourceLocation srcloc = decl->getLocation();
             // always exclude system headers
             if (src_mgr.isInSystemHeader(srcloc) ||
@@ -767,10 +783,43 @@ class FindFunctionConsumer : public clang::ASTConsumer
 class FindFunctionAction : public ASTFrontendAction
 {
   public:
-    virtual std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance &Compiler, llvm::StringRef InFile)
+    std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance &Compiler, llvm::StringRef InFile) override
     {
         return std::make_unique<FindFunctionConsumer>(&Compiler.getASTContext(), Compiler.getSourceManager());
     }
+
+    void ExecuteAction() override
+    {
+        if (!fabricate_unknown_types)
+        {
+            ASTFrontendAction::ExecuteAction();
+            return;
+        }
+        CompilerInstance &CI = getCompilerInstance();
+        if (!CI.hasPreprocessor())
+        {
+            return;
+        }
+        if (!CI.hasSema())
+        {
+            CI.createSema(getTranslationUnitKind(), nullptr);
+        }
+        fabricator = llvm::makeIntrusiveRefCnt<salt::SaltSemaFabricator>();
+        fabricator->InitializeSema(CI.getSema());
+#if LLVM_VERSION_MAJOR >= 22
+        CI.getSema().addExternalSource(fabricator);
+#else
+        CI.getSema().addExternalSource(fabricator.get());
+#endif
+        ParseAST(CI.getSema(), CI.getFrontendOpts().ShowStats,
+                 CI.getFrontendOpts().SkipFunctionBodies);
+        llvm::outs() << "Fabricated " << fabricator->numNamespaces()
+                     << " namespaces, " << fabricator->numTemplates()
+                     << " class templates\n";
+    }
+
+  private:
+    llvm::IntrusiveRefCntPtr<salt::SaltSemaFabricator> fabricator;
 };
 
 instrumentor::instrumentor()

--- a/src/saltfm.in
+++ b/src/saltfm.in
@@ -36,22 +36,23 @@ OPTIONS:
 
 Generic SALT-FM Options:
 
-  -h                           - Alias for --help
-  --help                       - Display available options (--help-hidden for more)
-  --help-fortran               - Display Fortran instrumentor options and usage information
-  --help-c                     - Display C/C++ instrumentor options and usage information
-  --help-cxx                   - Display C/C++ instrumentor options and usage information
-  --version                    - Display the version of this program
-  --lang=<string>              - Specify the language of the input source file (default: auto-detect)
-  --show                       - Print the command line that would be executed by the outter wrapper script
+  -h                            - Alias for --help
+  --help                        - Display available options (--help-hidden for more)
+  --help-fortran                - Display Fortran instrumentor options and usage information
+  --help-c                      - Display C/C++ instrumentor options and usage information
+  --help-cxx                    - Display C/C++ instrumentor options and usage information
+  --version                     - Display the version of this program
+  --lang=<string>               - Specify the language of the input source file (default: auto-detect)
+  --show                        - Print the command line that would be executed by the outter wrapper script
 
 TAU instrumentor options:
 
-  --config_file=<filename>     - Specify path to SALT-FM configuration YAML file
-  --tau_instrument_inline      - Instrument inlined functions (default: false)
-  --tau_output=<filename>      - Specify name of output instrumented file
-  --tau_select_file=<filename> - Provide a selective instrumentation specification file
-  --tau_use_cxx_api            - Use TAU's C++ instrumentation API
+  --config_file=<filename>      - Specify path to SALT-FM configuration YAML file
+  --tau_fabricate_unknown_types - Fabricate declarations for unknown qualified names (default: false)
+  --tau_instrument_inline       - Instrument inlined functions (default: false)
+  --tau_output=<filename>       - Specify name of output instrumented file
+  --tau_select_file=<filename>  - Provide a selective instrumentation specification file
+  --tau_use_cxx_api             - Use TAU's C++ instrumentation API
 EOF
 
 # Add a help/usage message function

--- a/src/sema_fabricator.cpp
+++ b/src/sema_fabricator.cpp
@@ -1,0 +1,132 @@
+#include "sema_fabricator.hpp"
+
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/Decl.h"
+#include "clang/AST/DeclCXX.h"
+#include "clang/AST/DeclTemplate.h"
+#include "clang/Sema/Lookup.h"
+#include "clang/Sema/Sema.h"
+
+using namespace clang;
+
+namespace salt
+{
+
+void SaltSemaFabricator::InitializeSema(Sema &S)
+{
+    sema = &S;
+}
+
+// Check if we already created this type
+NamedDecl *SaltSemaFabricator::findExisting(DeclContext *DC, IdentifierInfo *II)
+{
+    for (NamedDecl *D : DC->lookup(DeclarationName(II)))
+    {
+        return D;
+    }
+    return nullptr;
+}
+
+// Create namespace for encountered unresolved namespace
+NamespaceDecl *SaltSemaFabricator::fabricateNamespace(DeclContext *DC,
+                                                      IdentifierInfo *II)
+{
+    ASTContext &Ctx = sema->getASTContext();
+    NamespaceDecl *ND =
+        NamespaceDecl::Create(Ctx, DC, /*Inline=*/false, SourceLocation(),
+                              SourceLocation(), II, /*PrevDecl=*/nullptr,
+                              /*Nested=*/false);
+    ND->setImplicit(true);
+    DC->addDecl(ND);
+    ++num_namespaces;
+    return ND;
+}
+
+// Create class template for encountered unresolved class template
+ClassTemplateDecl *SaltSemaFabricator::fabricateClassTemplate(DeclContext *DC,
+                                                              IdentifierInfo *II)
+{
+    ASTContext &Ctx = sema->getASTContext();
+    TemplateTypeParmDecl *TTP = TemplateTypeParmDecl::Create(
+        Ctx, Ctx.getTranslationUnitDecl(), SourceLocation(), SourceLocation(),
+        /*Depth=*/0, /*Position=*/0, /*Id=*/nullptr, /*Typename=*/true,
+        /*ParameterPack=*/true);
+    NamedDecl *Params[] = {TTP};
+    TemplateParameterList *TPL = TemplateParameterList::Create(
+        Ctx, SourceLocation(), SourceLocation(), Params, SourceLocation(),
+        nullptr);
+    CXXRecordDecl *RD = CXXRecordDecl::Create(
+        Ctx, TagTypeKind::Class, DC, SourceLocation(), SourceLocation(), II);
+    RD->setImplicit(true);
+    ClassTemplateDecl *CTD = ClassTemplateDecl::Create(
+        Ctx, DC, SourceLocation(), DeclarationName(II), TPL, RD);
+    CTD->setImplicit(true);
+    RD->setDescribedClassTemplate(CTD);
+    DC->addDecl(CTD);
+    ++num_templates;
+    return CTD;
+}
+
+TypoCorrection SaltSemaFabricator::CorrectTypo(
+    const DeclarationNameInfo &Typo, int LookupKind, Scope *S, CXXScopeSpec *SS,
+    CorrectionCandidateCallback &CCC, DeclContext *MemberContext,
+    bool EnteringContext, const ObjCObjectPointerType *OPT)
+{
+    IdentifierInfo *II = Typo.getName().getAsIdentifierInfo();
+    if (!II || !sema)
+    {
+        // Returning an empty TypoCorrection makes no corrections.
+        return TypoCorrection();
+    }
+    if (!sema->getLangOpts().CPlusPlus)
+    {
+        // Namespace/template fabrication is only relevant for C++
+        return TypoCorrection();
+    }
+
+    DeclContext *DC = sema->getASTContext().getTranslationUnitDecl();
+    if (SS && SS->isNotEmpty())
+    {
+        DeclContext *C = sema->computeDeclContext(*SS, EnteringContext);
+        if (!C)
+        {
+            return TypoCorrection();
+        }
+        DC = C;
+    }
+
+    // Never mutate non-file contexts
+    if (!DC->isFileContext())
+    {
+        return TypoCorrection();
+    }
+
+    // On unknown name before '::', fabricate a namespace
+    if (LookupKind == Sema::LookupNestedNameSpecifierName)
+    {
+        NamedDecl *D = findExisting(DC, II);
+        if (!D)
+        {
+            D = fabricateNamespace(DC, II);
+        }
+        TypoCorrection TC(II);
+        TC.addCorrectionDecl(D);
+        return TC;
+    }
+
+    // Otherwise, fabricate a class template
+    if (SS && SS->isNotEmpty())
+    {
+        NamedDecl *D = findExisting(DC, II);
+        if (!D)
+        {
+            D = fabricateClassTemplate(DC, II);
+        }
+        TypoCorrection TC(II);
+        TC.addCorrectionDecl(D);
+        return TC;
+    }
+    return TypoCorrection();
+}
+
+} // namespace salt

--- a/src/sema_fabricator.cpp
+++ b/src/sema_fabricator.cpp
@@ -67,6 +67,22 @@ ClassTemplateDecl *SaltSemaFabricator::fabricateClassTemplate(DeclContext *DC,
     return CTD;
 }
 
+// Create a plain class for an encountered unresolved non-template type
+CXXRecordDecl *SaltSemaFabricator::fabricateRecord(DeclContext *DC,
+                                                   IdentifierInfo *II)
+{
+    ASTContext &Ctx = sema->getASTContext();
+    CXXRecordDecl *RD = CXXRecordDecl::Create(
+        Ctx, TagTypeKind::Class, DC, SourceLocation(), SourceLocation(), II);
+    RD->setImplicit(true);
+    // Give the class an empty definition
+    RD->startDefinition();
+    RD->completeDefinition();
+    DC->addDecl(RD);
+    ++num_records;
+    return RD;
+}
+
 TypoCorrection SaltSemaFabricator::CorrectTypo(
     const DeclarationNameInfo &Typo, int LookupKind, Scope *S, CXXScopeSpec *SS,
     CorrectionCandidateCallback &CCC, DeclContext *MemberContext,
@@ -114,13 +130,20 @@ TypoCorrection SaltSemaFabricator::CorrectTypo(
         return TC;
     }
 
-    // Otherwise, fabricate a class template
+    // Otherwise, fabricate a type for the unknown qualified name.
     if (SS && SS->isNotEmpty())
     {
         NamedDecl *D = findExisting(DC, II);
         if (!D)
         {
-            D = fabricateClassTemplate(DC, II);
+            if (CCC.WantTypeSpecifiers)
+            {
+                D = fabricateRecord(DC, II);
+            }
+            else
+            {
+                D = fabricateClassTemplate(DC, II);
+            }
         }
         TypoCorrection TC(II);
         TC.addCorrectionDecl(D);

--- a/tests/fabricate_case1.cpp
+++ b/tests/fabricate_case1.cpp
@@ -1,0 +1,3 @@
+int test(testns::lemur<int> p){
+  return 1;
+}

--- a/tests/fabricate_case2.cpp
+++ b/tests/fabricate_case2.cpp
@@ -1,0 +1,3 @@
+int test(lemur<int> p){
+  return 1;
+}

--- a/tests/fabricate_case3.cpp
+++ b/tests/fabricate_case3.cpp
@@ -1,0 +1,3 @@
+int test(float a, testns::lemur<int> p){
+  return 1;
+}

--- a/tests/fabricate_class_member.cpp
+++ b/tests/fabricate_class_member.cpp
@@ -1,0 +1,4 @@
+struct Real { int x; };
+int f(Real::Unknown p){
+  return 1;
+}

--- a/tests/fabricate_control.c
+++ b/tests/fabricate_control.c
@@ -1,0 +1,2 @@
+int add(int a, int b) { return a + b; }
+int main() { return add(1, 2); }

--- a/tests/fabricate_control.cpp
+++ b/tests/fabricate_control.cpp
@@ -1,0 +1,2 @@
+int add(int a, int b) { return a + b; }
+int main() { return add(1, 2); }

--- a/tests/fabricate_member_def.cpp
+++ b/tests/fabricate_member_def.cpp
@@ -1,0 +1,4 @@
+void MyClass::method(){
+}
+MyClass::MyClass(){
+}

--- a/tests/fabricate_mixed_kinds.cpp
+++ b/tests/fabricate_mixed_kinds.cpp
@@ -1,0 +1,6 @@
+int usesPlain(testns::Foo p){
+  return 1;
+}
+int usesTemplate(testns::lemur<int> q){
+  return 2;
+}

--- a/tests/fabricate_multi_param.cpp
+++ b/tests/fabricate_multi_param.cpp
@@ -1,0 +1,3 @@
+int test4(n1::t1<int> a, n2::t2<char> b){
+  return 4;
+}

--- a/tests/fabricate_nested_ns.cpp
+++ b/tests/fabricate_nested_ns.cpp
@@ -1,0 +1,3 @@
+int test2(aa::bb::cc<int> p){
+  return 2;
+}

--- a/tests/fabricate_nontype_args.cpp
+++ b/tests/fabricate_nontype_args.cpp
@@ -1,0 +1,3 @@
+int test(testns::arr<int, 3> p){
+  return 1;
+}

--- a/tests/fabricate_plain_qualified.cpp
+++ b/tests/fabricate_plain_qualified.cpp
@@ -1,0 +1,3 @@
+int test(testns::Foo p){
+  return 1;
+}

--- a/tests/fabricate_return_type.cpp
+++ b/tests/fabricate_return_type.cpp
@@ -1,0 +1,3 @@
+qq::rr<float> test3(int x){
+  return {};
+}

--- a/tests/fabricate_reuse.cpp
+++ b/tests/fabricate_reuse.cpp
@@ -1,0 +1,6 @@
+int first(testns::lemur<int> p){
+  return 1;
+}
+int second(testns::lemur<int> p){
+  return 2;
+}

--- a/tests/fabricate_srctext_comment.cpp
+++ b/tests/fabricate_srctext_comment.cpp
@@ -1,0 +1,3 @@
+void commented(std::vector<RealD> // this comment contains "double quotes" inside the signature
+                   &w) {
+}

--- a/tests/fabricate_srctext_default_arg.cpp
+++ b/tests/fabricate_srctext_default_arg.cpp
@@ -1,0 +1,2 @@
+void withDefault(testns::tmpl<int> p = {}) {
+}

--- a/tests/fabricate_srctext_fallback.cpp
+++ b/tests/fabricate_srctext_fallback.cpp
@@ -1,0 +1,2 @@
+void fallbackUnnamed(std::vector<RealD>) {
+}

--- a/tests/fabricate_srctext_fn_template.cpp
+++ b/tests/fabricate_srctext_fn_template.cpp
@@ -1,0 +1,2 @@
+template <class T> void tmplFn(std::vector<RealD> &v, T t) {
+}

--- a/tests/fabricate_srctext_multiline.cpp
+++ b/tests/fabricate_srctext_multiline.cpp
@@ -1,0 +1,4 @@
+void multiline(std::vector<
+                   RealD> &v,
+               const int n) {
+}

--- a/tests/fabricate_srctext_zmobius.cpp
+++ b/tests/fabricate_srctext_zmobius.cpp
@@ -1,0 +1,5 @@
+void computeZmobiusOmega(std::vector<ComplexD> &omega_out, const int Ls_out,
+                         const std::vector<RealD> &omega_in, const int Ls_in,
+                         const RealD lambda_bound){
+//commented out code
+}


### PR DESCRIPTION
Currently, when encountering unknown types, Clang's default error resolution mechanism is used, which may result in misparses for certain function definitions. Clang provides hooks for tools to provide their own error resolution. Here we use Clang's `ExternalSemaSource` to correct unknown types encountered during parsing by creating the corresponding namespace, qualified type, or class template. We also derive the types in the timer name from the spelled types rather than the semantic types if any of the types were invalid, to prevent unknown unqualified types from degrading to `int` in timer names. Adds new tests to validate that this enables parsing of function signatures with unknown types.

With these changes, functions like
```c++
int test(testns::lemur<int> p){
  return 1;
}
```
will be instrumented.

Type fabrication is off by default and is enabled with the new option `--tau_fabricate_unknown_types` or the env var `SALT_FABRICATE_UNKNOWN_TYPES`.