### PR TITLE
Fix handling of `--tau_instrument_inline`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -930,6 +930,63 @@ set_tests_properties(check_pure_virtual_skips_bodyless
     "TAU_PROFILE_TIMER[^\n]*Abstract::unimplemented;TAU_PROFILE_TIMER[^\n]*undefined_free_fn"
 )
 
+# --tau_instrument_inline tests
+# Verify that inline functions are skipped without flag
+# and are instrumented with it
+add_test(NAME instrument_inline_off
+  COMMAND
+    ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}/saltfm
+    --tau_output=instrument_inline_off.inst.cpp
+    ${CMAKE_SOURCE_DIR}/tests/instrument_inline.cpp)
+set_tests_properties(instrument_inline_off
+  PROPERTIES
+  REQUIRED_FILES "${CMAKE_SOURCE_DIR}/tests/instrument_inline.cpp"
+  LABELS "lang:CXX;phase:instrument"
+  PASS_REGULAR_EXPRESSION "[Ii]nstrumentation:"
+)
+
+add_test(NAME check_inline_off_skips_inline
+  COMMAND ${CMAKE_COMMAND} -E cat instrument_inline_off.inst.cpp)
+set_tests_properties(check_inline_off_skips_inline
+  PROPERTIES
+  DEPENDS instrument_inline_off
+  LABELS "lang:CXX;phase:check"
+  PASS_REGULAR_EXPRESSION "TAU_PROFILE_SET_NODE"
+  FAIL_REGULAR_EXPRESSION
+    "TAU_PROFILE_TIMER[^\n]*method_in_class_body;TAU_PROFILE_TIMER[^\n]*free_fn_marked_inline"
+)
+
+add_test(NAME instrument_inline_on
+  COMMAND
+    ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}/saltfm
+    --tau_instrument_inline
+    --tau_output=instrument_inline_on.inst.cpp
+    ${CMAKE_SOURCE_DIR}/tests/instrument_inline.cpp)
+set_tests_properties(instrument_inline_on
+  PROPERTIES
+  REQUIRED_FILES "${CMAKE_SOURCE_DIR}/tests/instrument_inline.cpp"
+  LABELS "lang:CXX;phase:instrument"
+  PASS_REGULAR_EXPRESSION "[Ii]nstrumentation:"
+)
+
+add_test(NAME check_inline_on_instruments_method
+  COMMAND ${CMAKE_COMMAND} -E cat instrument_inline_on.inst.cpp)
+set_tests_properties(check_inline_on_instruments_method
+  PROPERTIES
+  DEPENDS instrument_inline_on
+  LABELS "lang:CXX;phase:check"
+  PASS_REGULAR_EXPRESSION "TAU_PROFILE_TIMER[^\n]*method_in_class_body"
+)
+
+add_test(NAME check_inline_on_instruments_free_fn
+  COMMAND ${CMAKE_COMMAND} -E cat instrument_inline_on.inst.cpp)
+set_tests_properties(check_inline_on_instruments_free_fn
+  PROPERTIES
+  DEPENDS instrument_inline_on
+  LABELS "lang:CXX;phase:check"
+  PASS_REGULAR_EXPRESSION "TAU_PROFILE_TIMER[^\n]*free_fn_marked_inline"
+)
+
 # Selective Instrumentation File (SIF) tests.
 #
 # Each test runs the SALT instrumentor against a small source file containing

--- a/include/instrumentor.hpp
+++ b/include/instrumentor.hpp
@@ -60,7 +60,6 @@ bool check_file_against_list(std::list<std::string> list, std::string fname);
 static std::vector<inst_loc*> inst_locs;
 static std::vector<std::string> files_to_go;
 static std::vector<std::string> files_skipped;
-static bool inst_inline = false;
 
 class instrumentor {
 public:

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -309,8 +309,6 @@ int main(int argc, const char **argv)
     CodeInstrumentor.Tool = new tooling::ClangTool(OptionsParser.getCompilations(), OptionsParser.getSourcePathList());
     CodeInstrumentor.set_exec_name(argv[0]);
 
-    inst_inline = do_inline;
-
     if (!selectfile.empty())
     {
         processInstrumentationRequests(selectfile.c_str());

--- a/src/instrumentor.cpp
+++ b/src/instrumentor.cpp
@@ -873,7 +873,7 @@ class FindFunctionVisitor : public RecursiveASTVisitor<FindFunctionVisitor>
         // }
         // short circuit on hasBody() first to protect check_func_against_list (and makeFuncInstLoc) from segfaults
         if (func->hasBody() &&
-            (!func->isInlined() || inst_inline || check_func_against_list(includelist, func, context, src_mgr)))
+            (!func->isInlined() || do_inline || check_func_against_list(includelist, func, context, src_mgr)))
         { //
             makeFuncInstLoc(func);
             return_visitor.encl_function = func;

--- a/tests/instrument_inline.cpp
+++ b/tests/instrument_inline.cpp
@@ -1,0 +1,20 @@
+#include <iostream>
+
+class Widget {
+public:
+    int method_in_class_body(int value) {
+        std::cout << value << std::endl;
+        return value;
+    }
+};
+
+inline int free_fn_marked_inline() {
+    return 1234;
+}
+
+int main() {
+    Widget w;
+    w.method_in_class_body(1);
+    std::cout << free_fn_marked_inline() << std::endl;
+    return 0;
+}


### PR DESCRIPTION
`--tau_instrument_inline` had no effect because it was stored in `static bool inst_inline` in `include/instrumentor.hpp`. Because this was a static in a header, each translation unit had its own independent copy, and setting it in the frontend had no effect on the instrumentor. This is fixed by removing it and using the already-shared `do_inline` instead. Tests are added to verify that in-method and explicitly inline functions are skipped by default, but are instrumented with `--tau_instrument_inline`.

Fixes #68 